### PR TITLE
Allow tibble taxonomies

### DIFF
--- a/R/meltt.taxonomy.R
+++ b/R/meltt.taxonomy.R
@@ -10,7 +10,7 @@ meltt.taxonomy <- function(data,taxonomies){
     # save as a numerical matrix
 
     inputs <- data[,c("data.source","obs.count",tax_names[i])]
-    temp_tax <- taxonomies[[i]]
+    temp_tax <- as.data.frame(taxonomies[[i]])
 
 
     # TAXONOMY CLEANING


### PR DESCRIPTION
If input datasets are tibbles, `meltt()` still works, but if the taxonomies are tibbles, it will fail. This failure manifests as a failure to map every single value in each taxonomy category. I've updated `meltt.taxonomy.R` to convert each taxonomy to a data frame to deal with this. `devtools::check()` fails with the following, but I can build and install the package without error and `devtools::check()` fails the same way on master, so I think it's just something with my configuration. When running the patched `meltt()`, it succeeds when the taxonomies are a list of tibbles.

```
> checking examples with --run-donttest ... ERROR
  Running examples in ‘meltt-Ex.R’ failed
  The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
  > ### Name: is.meltt
  > ### Title: Tests for objects of type meltt.
  > ### Aliases: is.meltt
  > 
  > ### ** Examples
  > 
  > ## No test: 
  > data(crashMD)
  > output <- meltt(crash_data1,crash_data2,crash_data3,
  +                 taxonomies = crash_taxonomies,twindow = 1,spatwindow = 3)
   meltt: Matching Event Data by Location, Time and Type.
   Karsten Donnay and Eric Dunford, 2018
  
   NOTE: Depending on the size and number of datasets integration may take some time!
  
  
   meltt(crash_data1, crash_data2, crash_data3, taxonomies = crash_taxonomies, 
      twindow = 1, spatwindow = 3)
  
   Checking meltt() arguments and inputs:  ----------- FAILURE REPORT -------------- 
   --- failure: length > 1 in coercion to logical ---
   --- srcref --- 
  : 
   --- package (from environment) --- 
  meltt
   --- call from context --- 
  NULL
   --- call from argument --- 
  class(datecheck) == "try-error" || is.na(datecheck)
   --- R stacktrace ---
  where 1: meltt(crash_data1, crash_data2, crash_data3, taxonomies = crash_taxonomies, 
      twindow = 1, spatwindow = 3)
  
   --- value of length: 71 type: logical ---
   [1] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
  [13] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
  [25] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
  [37] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
  [49] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
  [61] FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE FALSE
   --- function from context --- 
   --- function search by body ---
   ----------- END OF FAILURE REPORT -------------- 
  Error in class(datecheck) == "try-error" || is.na(datecheck) : 
    'length(x) = 71 > 1' in coercion to 'logical(1)'
  Calls: meltt
  Execution halted

> checking compilation flags used ... WARNING
  Compilation used the following non-portable flag(s):
    ‘-Wno-unused-function’ ‘-Wno-unused-variable’ ‘-march=native’
  including flag(s) suppressing warnings

> checking top-level files ... NOTE
  File
    LICENSE
  is not mentioned in the DESCRIPTION file.
  Non-standard file/directory found at top level:
    ‘README_files’

1 error x | 1 warning x | 1 note x
```